### PR TITLE
Added missing utils package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ typing-extensions
 pyaudio
 phonemizer
 wget
+utils
 omegaconf
 pytorch_lightning
 git+https://github.com/resemble-ai/monotonic_align.git


### PR DESCRIPTION
After installing the requirements and running `main.py` I received a `ModuleNotFoundError` for utils.
I believe `style_tts2_model.py` requires this package, therefore I've added it to the `requirements.txt`.